### PR TITLE
DF-309:Insights Page errored when run via Cron

### DIFF
--- a/tna/collections/management/commands/fetch_results_pages.py
+++ b/tna/collections/management/commands/fetch_results_pages.py
@@ -99,6 +99,12 @@ class Command(BaseCommand):
             except Exception:
                 print(f"Error in fetch_results_pages traceback= {traceback.format_exc()}")
                 num_urls_errored += 1
+                # AttributeError: 'NoneType' object has no attribute '_inc_path'
+                # numchild field value on the parent is updated in memory, 
+                # even though the change might not be committed to the db.
+                # so refresh from db
+                print(f"Refreshing from db results_index_page")
+                results_index_page.refresh_from_db(fields=['numchild'])
 
         print(f"Number of urls fetched = {num_urls_fetched}")
         print(f"Number of urls created = {num_urls_created}")

--- a/tna/insights/management/commands/fetch_insights_pages.py
+++ b/tna/insights/management/commands/fetch_insights_pages.py
@@ -88,6 +88,12 @@ class Command(BaseCommand):
             except Exception as e:
                 print(f"Error in fetch_insights_pages traceback= {traceback.format_exc()}")
                 num_urls_errored += 1
+                # AttributeError: 'NoneType' object has no attribute '_inc_path'
+                # numchild field value on the parent is updated in memory, 
+                # even though the change might not be committed to the db.
+                # so refresh from db
+                print(f"Refreshing from db insights_index_page")
+                insights_index_page.refresh_from_db(fields=['numchild'])
 
         print(f"Number of urls fetched = {num_urls_fetched}")
         print(f"Number of urls created = {num_urls_created}")


### PR DESCRIPTION
Fixes Error: AttributeError: 'NoneType' object has no attribute '_inc_path'

Useful info:
https://docs.djangoproject.com/en/4.0/ref/models/instances/#django.db.models.Model.refresh_from_db
https://django-treebeard.readthedocs.io/en/latest/mp_tree.html

@ababic Thanks for this fix